### PR TITLE
Remove Eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,0 @@
-/*eslint-env node*/
-module.exports = {
-  extends: ['@lessonly'],
-};

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
-# Plataformatec linters and static analysis configuration files
+# Lessonly linters and static analysis configuration files
 
 A collection of configuration files we use for source code linters and static
 analysis tools.
 
 * [Credo](http://github.com/rrrene/credo) - [`.credo.exs`](.credo.exs)
-* [ESLint](https://github.com/eslint/eslint) - [`.eslintrc.js`](.eslintrc.js)
 * [Reek](http://github.com/troessner/reek) - [`.defaults.reek`](.defaults.reek)
 * [RuboCop](http://github.com/bbatsov/rubocop/pull/2416) - [`.rubocop.yml`](.rubocop.yml)
 * [SCSS Lint](https://github.com/brigade/scss-lint) - [`.scss-lint.yml`](.scss-lint.yml)


### PR DESCRIPTION
We no longer use Eslint through Ebert/SourceLevel so we should remove it from the configs here.